### PR TITLE
fix: span is an inline element not valid to wrap block elements

### DIFF
--- a/src/components/container/message/message-item.ts
+++ b/src/components/container/message/message-item.ts
@@ -309,10 +309,10 @@ export class ChatMessageItem extends LitElement {
                 .fontSize="${1.4}"
               ></chat-deleted-message>`
             : this.message.content !== ""
-              ? html`<span
+              ? html`<div
                   >${this.isMarkdownAvailable
                     ? unsafeHTML(this._content)
-                    : this._content}</span
+                    : this._content}</div
                 >`
               : nothing}
           ${!this.message.isDeleted && this.message.attachments.length > 0

--- a/test/unit/components/container/message/message-item.test.ts
+++ b/test/unit/components/container/message/message-item.test.ts
@@ -308,8 +308,8 @@ describe("chat-message-item", () => {
     );
 
     const body = el.shadowRoot?.querySelector(".message-item__body");
-    const span = body?.querySelector("span");
-    expect(span?.textContent).toBe("Hello, World!");
+    const div = body?.querySelector("div");
+    expect(div?.textContent).toBe("Hello, World!");
   });
 
   it("renders markdown content", async () => {
@@ -322,8 +322,8 @@ describe("chat-message-item", () => {
     );
 
     const body = el.shadowRoot?.querySelector(".message-item__body");
-    const span = body?.querySelector("span");
-    expect(span?.textContent).toBe("Mocked markdown content");
+    const div = body?.querySelector("div");
+    expect(div?.textContent).toBe("Mocked markdown content");
   });
 
   it("renders attachments", async () => {


### PR DESCRIPTION
Markdown renderer will output block elements (like `<p>`, `<ul>`, `<h1>`, etc.), and HTML specifications do not allow block-level elements to be direct children of inline-level elements (like `<span>`).  Therefore, using <span> element is incorrect here, as it cannot syntactically or semantically wrap a block-level element in valid HTML.

Component render and tests have been updated to wrap message content with a `<div>` element instead.